### PR TITLE
Switch to load using the updated EngineLoader code if it is present

### DIFF
--- a/facebook/manifests/web/engine_template.html
+++ b/facebook/manifests/web/engine_template.html
@@ -23,7 +23,7 @@
         var fb = document.createElement('script');
         fb.type = 'text/javascript';
         fb.src = '//connect.facebook.net/en_US/sdk.js';
-        fb.onload = load_engine;
+        fb.onload = (typeof load_engine === "function") ? load_engine : EngineLoader.load;
         document.head.appendChild(fb);
     </script>
 </body>


### PR DESCRIPTION
We updated the dmloader.js code while fixing progress bar load issues when loading web assembly and at the same time changed some function names, which broke the Facebook html snippet. This PR changes to use of the new EngineLoader.load function if it exists